### PR TITLE
Custom Avatar Parameters, bug fixes, ui improvements

### DIFF
--- a/MigrationInstaller/MigrationInstaller.csproj
+++ b/MigrationInstaller/MigrationInstaller.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0-windows</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishAot>true</PublishAot>

--- a/ShockOsc/Config/AvatarParameterAction.cs
+++ b/ShockOsc/Config/AvatarParameterAction.cs
@@ -1,0 +1,32 @@
+using OpenShock.Desktop.ModuleBase.Models;
+
+namespace OpenShock.ShockOSC.Config;
+
+public sealed class AvatarParameterAction
+{
+    public required string ParameterName { get; set; }
+    public ControlType Action { get; set; } = ControlType.Shock;
+    public Guid GroupId { get; set; }
+    public ParameterTriggerKind TriggerKind { get; set; } = ParameterTriggerKind.OnTrue;
+    public float Threshold { get; set; } = 0.5f;
+    public byte? OverrideIntensity { get; set; }
+    public ushort? OverrideDuration { get; set; }
+}
+
+public enum ParameterTriggerKind
+{
+    /// <summary>
+    /// Triggers when a bool parameter becomes true
+    /// </summary>
+    OnTrue,
+
+    /// <summary>
+    /// Triggers when a float parameter exceeds the threshold
+    /// </summary>
+    Threshold,
+
+    /// <summary>
+    /// Triggers on any value change (non-default)
+    /// </summary>
+    OnChange
+}

--- a/ShockOsc/Config/AvatarParameterAction.cs
+++ b/ShockOsc/Config/AvatarParameterAction.cs
@@ -21,6 +21,11 @@ public enum ParameterTriggerKind
     OnTrue,
 
     /// <summary>
+    /// Triggers when a bool parameter becomes false
+    /// </summary>
+    OnFalse,
+
+    /// <summary>
     /// Triggers when a float parameter exceeds the threshold
     /// </summary>
     Threshold,

--- a/ShockOsc/Config/AvatarParameterAction.cs
+++ b/ShockOsc/Config/AvatarParameterAction.cs
@@ -11,6 +11,9 @@ public sealed class AvatarParameterAction
     public float Threshold { get; set; } = 0.5f;
     public byte? OverrideIntensity { get; set; }
     public ushort? OverrideDuration { get; set; }
+    public bool IsLiveControl { get; set; }
+    public float LiveControlMin { get; set; }
+    public float LiveControlMax { get; set; } = 1f;
 }
 
 public enum ParameterTriggerKind

--- a/ShockOsc/Config/BehaviourConf.cs
+++ b/ShockOsc/Config/BehaviourConf.cs
@@ -5,4 +5,5 @@ public sealed class BehaviourConf : SharedBehaviourConfig
     public uint HoldTime { get; set; } = 250;
     public bool DisableWhileAfk { get; set; } = true;
     public bool ForceUnmute { get; set; }
+    public uint CheckLoopIntervalMs { get; set; } = 50;
 }

--- a/ShockOsc/Config/ShockOscConfig.cs
+++ b/ShockOsc/Config/ShockOscConfig.cs
@@ -9,6 +9,12 @@ public sealed class ShockOscConfig
     public ChatboxConf Chatbox { get; set; } = new();
     public IDictionary<Guid, Group> Groups { get; set; } = new Dictionary<Guid, Group>();
 
+    /// <summary>
+    /// Custom parameter-to-action mappings, keyed by avatar ID
+    /// </summary>
+    public IDictionary<string, IList<AvatarParameterAction>> AvatarParameterActions { get; set; } =
+        new Dictionary<string, IList<AvatarParameterAction>>();
+
     public T GetGroupOrGlobal<T>(ProgramGroup group, Func<SharedBehaviourConfig, T> selector,
         Func<Group, bool> groupOverrideSelector)
     {

--- a/ShockOsc/Services/OscHandler.cs
+++ b/ShockOsc/Services/OscHandler.cs
@@ -84,9 +84,13 @@ public sealed class OscHandler
 
         foreach (var shocker in _shockOscData.ProgramGroups.Values)
         {
+            var cooldownTime = _moduleConfig.Config.Behaviour.CooldownTime;
+            if (shocker.ConfigGroup is { OverrideCooldownTime: true })
+                cooldownTime = shocker.ConfigGroup.CooldownTime;
+
             var isActive = shocker.LastExecuted.AddMilliseconds(shocker.LastDuration) > DateTime.UtcNow;
             var isActiveOrOnCooldown =
-                shocker.LastExecuted.AddMilliseconds(_moduleConfig.Config.Behaviour.CooldownTime)
+                shocker.LastExecuted.AddMilliseconds(cooldownTime)
                     .AddMilliseconds(shocker.LastDuration) > DateTime.UtcNow;
             if (!isActiveOrOnCooldown && shocker.LastIntensity > 0)
                 shocker.LastIntensity = 0;
@@ -100,7 +104,7 @@ public sealed class OscHandler
                                                                 shocker.LastExecuted.AddMilliseconds(
                                                                     shocker.LastDuration))
                                                         .TotalMilliseconds /
-                                                        _moduleConfig.Config.Behaviour.CooldownTime);
+                                                        cooldownTime);
 
             await shocker.ParamActive.SetValue(isActive);
             await shocker.ParamCooldown.SetValue(onCoolDown);

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -581,10 +581,10 @@ public sealed class ShockOsc
 
     private async Task SenderLoopAsync(CancellationToken ct)
     {
-        while (!ct.IsCancellationRequested)
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(300));
+        while (await timer.WaitForNextTickAsync(ct))
         {
             await _oscHandler.SendParams();
-            await Task.Delay(300, ct);
         }
     }
 
@@ -653,7 +653,8 @@ public sealed class ShockOsc
 
     private async Task CheckLoop(CancellationToken ct)
     {
-        while (!ct.IsCancellationRequested)
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
+        while (await timer.WaitForNextTickAsync(ct))
         {
             try
             {
@@ -663,8 +664,6 @@ public sealed class ShockOsc
             {
                 _logger.LogError(e, "Error in check loop");
             }
-
-            await Task.Delay(20, ct);
         }
     }
 

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -125,7 +125,8 @@ public sealed class ShockOsc
     {
         // Stop existing loops
         await _loopCts.CancelAsync();
-        await Task.WhenAll(_loopTasks);
+        try { await Task.WhenAll(_loopTasks); }
+        catch (OperationCanceledException) { }
         _loopCts.Dispose();
         _loopCts = new CancellationTokenSource();
 

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -653,7 +653,8 @@ public sealed class ShockOsc
 
     private async Task CheckLoop(CancellationToken ct)
     {
-        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(50));
+        var intervalMs = Math.Max(10, _moduleConfig.Config.Behaviour.CheckLoopIntervalMs);
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(intervalMs));
         while (await timer.WaitForNextTickAsync(ct))
         {
             try

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -32,7 +32,8 @@ public sealed class ShockOsc
     private readonly OscHandler _oscHandler;
     private readonly ChatboxService _chatboxService;
 
-    private bool _oscServerActive;
+    private CancellationTokenSource _loopCts = new();
+    private Task[] _loopTasks = [];
     private bool _isAfk;
     public bool IsGameConnected { get; private set; }
     public bool IsConnectedViaOscQuery { get; private set; }
@@ -121,12 +122,15 @@ public sealed class ShockOsc
 
     private async Task SetupVrcClient((OscQueryServer, IPEndPoint)? client)
     {
-        // stop tasks
-        _oscServerActive = false;
+        // Stop existing loops
+        await _loopCts.CancelAsync();
+        await Task.WhenAll(_loopTasks);
+        _loopCts.Dispose();
+        _loopCts = new CancellationTokenSource();
+
         IsGameConnected = false;
         IsConnectedViaOscQuery = false;
         OnGameConnectionChanged?.Invoke();
-        await Task.Delay(1000); // wait for tasks to stop TODO: REWORK THIS
 
         if (client != null)
         {
@@ -144,13 +148,17 @@ public sealed class ShockOsc
         _logger.LogInformation("Connecting UDP Clients...");
 
         // Start tasks
-        _oscServerActive = true;
+        var ct = _loopCts.Token;
+        _loopTasks =
+        [
+            Task.Run(() => ReceiverLoopAsync(ct), ct),
+            Task.Run(() => SenderLoopAsync(ct), ct),
+            Task.Run(() => CheckLoop(ct), ct)
+        ];
+
         IsGameConnected = true;
         IsConnectedViaOscQuery = client != null;
         OnGameConnectionChanged?.Invoke();
-        OsTask.Run(ReceiverLoopAsync);
-        OsTask.Run(SenderLoopAsync);
-        OsTask.Run(CheckLoop);
 
         _logger.LogInformation("Ready");
         OsTask.Run(_underscoreConfig.SendUpdateForAll);
@@ -261,35 +269,30 @@ public sealed class ShockOsc
         }
     }
 
-    private async Task ReceiverLoopAsync()
+    private async Task ReceiverLoopAsync(CancellationToken ct)
     {
-        while (_oscServerActive)
+        while (!ct.IsCancellationRequested)
         {
             try
             {
-                await ReceiveLogic();
+                var receiveTask = _oscClient.ReceiveGameMessage();
+                if (receiveTask == null) break;
+                await receiveTask.WaitAsync(ct);
+                await ReceiveLogic(receiveTask.Result);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Error in receiver loop");
             }
         }
-        // ReSharper disable once FunctionNeverReturns
     }
 
-    private async Task ReceiveLogic()
+    private async Task ReceiveLogic(OscMessage received)
     {
-        OscMessage received;
-        try
-        {
-            received = await _oscClient.ReceiveGameMessage()!;
-        }
-        catch (Exception e)
-        {
-            _logger.LogTrace(e, "Error receiving message");
-            return;
-        }
-
         var addr = received.Address;
 
         if (addr.StartsWith("/avatar/parameters/"))
@@ -576,12 +579,12 @@ public sealed class ShockOsc
         return _chatboxService.SendGenericMessage(_moduleConfig.Config.Chatbox.IgnoredAfk);
     }
 
-    private async Task SenderLoopAsync()
+    private async Task SenderLoopAsync(CancellationToken ct)
     {
-        while (_oscServerActive)
+        while (!ct.IsCancellationRequested)
         {
             await _oscHandler.SendParams();
-            await Task.Delay(300);
+            await Task.Delay(300, ct);
         }
     }
 
@@ -648,9 +651,9 @@ public sealed class ShockOsc
         await _chatboxService.SendLocalControlMessage(programGroup.Name, actualIntensity, actualDuration, type);
     }
 
-    private async Task CheckLoop()
+    private async Task CheckLoop(CancellationToken ct)
     {
-        while (_oscServerActive)
+        while (!ct.IsCancellationRequested)
         {
             try
             {
@@ -661,7 +664,7 @@ public sealed class ShockOsc
                 _logger.LogError(e, "Error in check loop");
             }
 
-            await Task.Delay(20);
+            await Task.Delay(20, ct);
         }
     }
 

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -34,6 +34,9 @@ public sealed class ShockOsc
 
     private bool _oscServerActive;
     private bool _isAfk;
+    public bool IsGameConnected { get; private set; }
+    public bool IsConnectedViaOscQuery { get; private set; }
+    public event Action? OnGameConnectionChanged;
     public string AvatarId = string.Empty;
     private readonly Random Random = new();
 
@@ -120,6 +123,9 @@ public sealed class ShockOsc
     {
         // stop tasks
         _oscServerActive = false;
+        IsGameConnected = false;
+        IsConnectedViaOscQuery = false;
+        OnGameConnectionChanged?.Invoke();
         await Task.Delay(1000); // wait for tasks to stop TODO: REWORK THIS
 
         if (client != null)
@@ -139,6 +145,9 @@ public sealed class ShockOsc
 
         // Start tasks
         _oscServerActive = true;
+        IsGameConnected = true;
+        IsConnectedViaOscQuery = client != null;
+        OnGameConnectionChanged?.Invoke();
         OsTask.Run(ReceiverLoopAsync);
         OsTask.Run(SenderLoopAsync);
         OsTask.Run(CheckLoop);

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -38,6 +38,7 @@ public sealed class ShockOsc
     public bool IsGameConnected { get; private set; }
     public bool IsConnectedViaOscQuery { get; private set; }
     public event Action? OnGameConnectionChanged;
+    public event Action<AvatarParameterAction>? OnAvatarActionTriggered;
     public string AvatarId = string.Empty;
     private readonly Random Random = new();
 
@@ -236,6 +237,7 @@ public sealed class ShockOsc
             var shouldTrigger = action.TriggerKind switch
             {
                 ParameterTriggerKind.OnTrue => newValue is true && oldValue is not true,
+                ParameterTriggerKind.OnFalse => newValue is false && oldValue is not false,
                 ParameterTriggerKind.Threshold => newValue is float f && f >= action.Threshold &&
                                                   (oldValue is not float oldF || oldF < action.Threshold),
                 ParameterTriggerKind.OnChange => !Equals(newValue, oldValue) && newValue is not null &&
@@ -265,6 +267,7 @@ public sealed class ShockOsc
                 "Custom parameter action triggered: {Param} -> {Action} on group {Group} (intensity: {Intensity}, duration: {Duration}ms)",
                 paramName, action.Action, programGroup.Name, intensity, duration);
 
+            OnAvatarActionTriggered?.Invoke(action);
             OsTask.Run(() => SendCommand(programGroup, duration, intensity, action.Action));
         }
     }

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -234,6 +234,40 @@ public sealed class ShockOsc
         {
             if (action.ParameterName != paramName) continue;
 
+            if (!_dataLayer.ProgramGroups.TryGetValue(action.GroupId, out var programGroup))
+            {
+                _logger.LogWarning("Custom parameter action references unknown group {GroupId}", action.GroupId);
+                continue;
+            }
+
+            if (action.IsLiveControl)
+            {
+                var rawValue = newValue switch
+                {
+                    float f => f,
+                    int i => i,
+                    true => action.LiveControlMax,
+                    _ => action.LiveControlMin
+                };
+
+                var range = action.LiveControlMax - action.LiveControlMin;
+                var liveIntensity = range == 0f
+                    ? 0f
+                    : MathUtils.Saturate((rawValue - action.LiveControlMin) / range);
+
+                var scaledIntensity = Convert.ToByte(liveIntensity * 100f);
+                if (action.OverrideIntensity.HasValue && scaledIntensity > 0)
+                    scaledIntensity = GetScaledIntensity(programGroup, scaledIntensity);
+
+                programGroup.ConcurrentIntensity = scaledIntensity;
+                programGroup.ConcurrentType = scaledIntensity > 0 ? action.Action : ControlType.Stop;
+
+                if (scaledIntensity > 0)
+                    OnAvatarActionTriggered?.Invoke(action);
+
+                continue;
+            }
+
             var shouldTrigger = action.TriggerKind switch
             {
                 ParameterTriggerKind.OnTrue => newValue is true && oldValue is not true,
@@ -246,12 +280,6 @@ public sealed class ShockOsc
             };
 
             if (!shouldTrigger) continue;
-
-            if (!_dataLayer.ProgramGroups.TryGetValue(action.GroupId, out var programGroup))
-            {
-                _logger.LogWarning("Custom parameter action references unknown group {GroupId}", action.GroupId);
-                continue;
-            }
 
             if (!CheckAndSetAllPreconditions(programGroup).IsT0)
             {

--- a/ShockOsc/Services/ShockOsc.cs
+++ b/ShockOsc/Services/ShockOsc.cs
@@ -61,6 +61,11 @@ public sealed class ShockOsc
     public readonly Dictionary<string, object?> ShockOscParams = new();
     public readonly Dictionary<string, object?> AllAvatarParams = new();
 
+    /// <summary>
+    /// Tracks previous values of avatar parameters for custom action trigger detection
+    /// </summary>
+    private readonly Dictionary<string, object?> _previousParamValues = new();
+
     public IObservable<bool> OnParamsChangeObservable => _onParamsChange;
     private readonly Subject<bool> _onParamsChange = new();
 
@@ -159,6 +164,7 @@ public sealed class ShockOsc
 
             ShockOscParams.Clear();
             AllAvatarParams.Clear();
+            _previousParamValues.Clear();
 
             foreach (var param in parameters.Keys)
             {
@@ -201,6 +207,51 @@ public sealed class ShockOsc
         return Task.CompletedTask;
     }
 
+    private void CheckCustomParameterAction(string paramName, object? oldValue, object? newValue)
+    {
+        if (string.IsNullOrEmpty(AvatarId)) return;
+        if (!_moduleConfig.Config.AvatarParameterActions.TryGetValue(AvatarId, out var actions)) return;
+
+        foreach (var action in actions)
+        {
+            if (action.ParameterName != paramName) continue;
+
+            var shouldTrigger = action.TriggerKind switch
+            {
+                ParameterTriggerKind.OnTrue => newValue is true && oldValue is not true,
+                ParameterTriggerKind.Threshold => newValue is float f && f >= action.Threshold &&
+                                                  (oldValue is not float oldF || oldF < action.Threshold),
+                ParameterTriggerKind.OnChange => !Equals(newValue, oldValue) && newValue is not null &&
+                                                 newValue is not false && newValue is not 0 && newValue is not 0f,
+                _ => false
+            };
+
+            if (!shouldTrigger) continue;
+
+            if (!_dataLayer.ProgramGroups.TryGetValue(action.GroupId, out var programGroup))
+            {
+                _logger.LogWarning("Custom parameter action references unknown group {GroupId}", action.GroupId);
+                continue;
+            }
+
+            if (!CheckAndSetAllPreconditions(programGroup).IsT0)
+            {
+                _logger.LogDebug("Custom parameter action skipped due to preconditions for group {Group}",
+                    programGroup.Name);
+                continue;
+            }
+
+            var intensity = action.OverrideIntensity ?? GetIntensity(programGroup);
+            var duration = action.OverrideDuration ?? GetDuration(programGroup);
+
+            _logger.LogInformation(
+                "Custom parameter action triggered: {Param} -> {Action} on group {Group} (intensity: {Intensity}, duration: {Duration}ms)",
+                paramName, action.Action, programGroup.Name, intensity, duration);
+
+            OsTask.Run(() => SendCommand(programGroup, duration, intensity, action.Action));
+        }
+    }
+
     private async Task ReceiverLoopAsync()
     {
         while (_oscServerActive)
@@ -236,11 +287,15 @@ public sealed class ShockOsc
         {
             // FIXME: less alloc pls
             var fullName = addr[19..];
+            var oldValue = AllAvatarParams.GetValueOrDefault(fullName);
             if (AllAvatarParams.ContainsKey(fullName))
                 AllAvatarParams[fullName] = received.Arguments[0];
             else
                 AllAvatarParams.TryAdd(fullName, received.Arguments[0]);
             _onParamsChange.OnNext(false);
+
+            // Check custom avatar parameter actions
+            CheckCustomParameterAction(fullName, oldValue, received.Arguments[0]);
         }
 
         switch (addr)

--- a/ShockOsc/ShockOSCModule.cs
+++ b/ShockOsc/ShockOSCModule.cs
@@ -38,6 +38,12 @@ public sealed class ShockOSCModule : DesktopModuleBase, IAsyncDisposable
         },
         new()
         {
+            Name = "Avatar Actions",
+            ComponentType = typeof(AvatarActionsTab),
+            Icon = IconOneOf.FromSvg(Icons.Material.Filled.Tune)
+        },
+        new()
+        {
             Name = "Chatbox",
             ComponentType = typeof(ChatboxTab),
             Icon = IconOneOf.FromSvg(Icons.Material.Filled.Chat)

--- a/ShockOsc/ShockOsc.csproj
+++ b/ShockOsc/ShockOsc.csproj
@@ -13,6 +13,7 @@
         <AssemblyVersion>3.1.0</AssemblyVersion>
         <Version>3.1.0</Version>
 
+        <OpenShockModuleId>openshock.shockosc</OpenShockModuleId>
         <Product>ShockOsc</Product>
 
         <ResourceLanguages>en</ResourceLanguages>
@@ -22,18 +23,18 @@
         <Configurations>Debug;Release</Configurations>
 
         <Platforms>AnyCPU</Platforms>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.8"/>
-        <PackageReference Include="MudBlazor" Version="8.11.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+        <PackageReference Include="MudBlazor" Version="9.2.0" />
         <PackageReference Include="EmbedIO" Version="3.5.2"/>
         <PackageReference Include="LucHeart.CoreOSC" Version="1.6.0"/>
         <PackageReference Include="MeaMod.DNS" Version="1.0.71"/>
-        <PackageReference Include="OpenShock.Desktop.ModuleBase" Version="1.1.0"/>
+        <PackageReference Include="OpenShock.Desktop.ModuleBase" Version="1.1.4" />
         <PackageReference Include="OscQueryLibrary" Version="1.2.0"/>
         <PackageReference Include="SmartFormat.NET" Version="3.6.1"/>
         <PackageReference Include="System.Reactive" Version="6.1.0"/>
@@ -51,5 +52,12 @@
         <EmbeddedResource Include="Resources\ShockOSC-Icon.svg"/>
     </ItemGroup>
 
+    <Target Name="CopyModuleToDesktop" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
+        <PropertyGroup>
+            <ModuleDestDir>$(APPDATA)\OpenShock\Desktop\modules\$(OpenShockModuleId)\</ModuleDestDir>
+        </PropertyGroup>
+        <MakeDir Directories="$(ModuleDestDir)" Condition="!Exists('$(ModuleDestDir)')" />
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ModuleDestDir)" />
+    </Target>
 
 </Project>

--- a/ShockOsc/ShockOsc.csproj
+++ b/ShockOsc/ShockOsc.csproj
@@ -10,8 +10,8 @@
         <RootNamespace>OpenShock.ShockOSC</RootNamespace>
         <Company>OpenShock</Company>
 
-        <AssemblyVersion>3.1.0</AssemblyVersion>
-        <Version>3.1.0</Version>
+        <AssemblyVersion>3.2.0</AssemblyVersion>
+        <Version>3.2.0-preview.1</Version>
 
         <OpenShockModuleId>openshock.shockosc</OpenShockModuleId>
         <Product>ShockOsc</Product>

--- a/ShockOsc/Ui/Pages/Dash/Tabs/AvatarActionsTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/AvatarActionsTab.razor
@@ -5,8 +5,10 @@
 @using OpenShock.ShockOSC.Config
 @using OpenShock.ShockOSC.Services
 @using OpenShock.ShockOSC.Ui.Utils
+@using OpenShock.ShockOSC.Utils
 
 @page "/dash/avatar-actions"
+@implements IAsyncDisposable
 
 @code {
 
@@ -29,6 +31,54 @@
 
     private AvatarParameterAction? _selectedAction;
     private string _parameterSearch = "";
+
+    private readonly Dictionary<AvatarParameterAction, DateTime> _lastTriggered = new();
+    private IDisposable? _paramsSubscription;
+    private readonly CancellationTokenSource _cts = new();
+    private bool _updateQueued;
+
+    protected override void OnInitialized()
+    {
+        _paramsSubscription = ShockOsc.OnParamsChangeObservable.Subscribe(_ => _updateQueued = true);
+        ShockOsc.OnAvatarActionTriggered += OnActionTriggered;
+        OsTask.Run(UpdateLoop);
+    }
+
+    private async Task UpdateLoop()
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(200));
+        while (await timer.WaitForNextTickAsync(_cts.Token))
+        {
+            if (!_updateQueued) continue;
+            _updateQueued = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private void OnActionTriggered(AvatarParameterAction action)
+    {
+        _lastTriggered[action] = DateTime.UtcNow;
+        _updateQueued = true;
+    }
+
+    private bool IsRecentlyTriggered(AvatarParameterAction action)
+    {
+        return _lastTriggered.TryGetValue(action, out var time) &&
+               (DateTime.UtcNow - time).TotalSeconds < 2;
+    }
+
+    private string GetCurrentValue(string paramName)
+    {
+        if (string.IsNullOrEmpty(paramName)) return "";
+        return ShockOsc.AllAvatarParams.TryGetValue(paramName, out var val) ? $"{val}" : "";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        ShockOsc.OnAvatarActionTriggered -= OnActionTriggered;
+        _paramsSubscription?.Dispose();
+        await _cts.CancelAsync();
+    }
 
     private void AddAction()
     {
@@ -62,6 +112,7 @@
         if (_selectedAction == action)
             _selectedAction = null;
 
+        _lastTriggered.Remove(action);
         ModuleConfig.SaveDeferred();
         InvokeAsync(StateHasChanged);
     }
@@ -97,6 +148,7 @@
         var trigger = action.TriggerKind switch
         {
             ParameterTriggerKind.OnTrue => "On True",
+            ParameterTriggerKind.OnFalse => "On False",
             ParameterTriggerKind.Threshold => $"Threshold >= {action.Threshold:F2}",
             ParameterTriggerKind.OnChange => "On Change",
             _ => "Unknown"
@@ -194,13 +246,24 @@ else
             <MudTable T="AvatarParameterAction" Items="CurrentActions" Hover="true" Dense="true"
                       SelectedItem="_selectedAction" SelectedItemChanged="OnSelectAction">
                 <HeaderContent>
+                    <MudTh Style="width: 16px;"></MudTh>
                     <MudTh>Parameter</MudTh>
+                    <MudTh>Value</MudTh>
                     <MudTh>Configuration</MudTh>
                     <MudTh Style="width: 50px;"></MudTh>
                 </HeaderContent>
                 <RowTemplate>
+                    <MudTd>
+                        @if (IsRecentlyTriggered(context))
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.ElectricBolt" Color="Color.Warning" Size="Size.Small"/>
+                        }
+                    </MudTd>
                     <MudTd DataLabel="Parameter">
                         @(string.IsNullOrEmpty(context.ParameterName) ? "(not set)" : context.ParameterName)
+                    </MudTd>
+                    <MudTd DataLabel="Value">
+                        <MudText Typo="Typo.body2" Style="opacity: 0.7;">@GetCurrentValue(context.ParameterName)</MudText>
                     </MudTd>
                     <MudTd DataLabel="Configuration">@GetActionSummary(context)</MudTd>
                     <MudTd>

--- a/ShockOsc/Ui/Pages/Dash/Tabs/AvatarActionsTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/AvatarActionsTab.razor
@@ -1,0 +1,302 @@
+@using OpenShock.Desktop.ModuleBase
+@using OpenShock.Desktop.ModuleBase.Api
+@using OpenShock.Desktop.ModuleBase.Config
+@using OpenShock.Desktop.ModuleBase.Models
+@using OpenShock.ShockOSC.Config
+@using OpenShock.ShockOSC.Services
+@using OpenShock.ShockOSC.Ui.Utils
+
+@page "/dash/avatar-actions"
+
+@code {
+
+    [ModuleInject] private IModuleConfig<ShockOscConfig> ModuleConfig { get; set; } = null!;
+    [ModuleInject] private ShockOsc ShockOsc { get; set; } = null!;
+    [ModuleInject] private IOpenShockService OpenShock { get; set; } = null!;
+
+    private string CurrentAvatarId => ShockOsc.AvatarId;
+
+    private IList<AvatarParameterAction> CurrentActions
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(CurrentAvatarId)) return [];
+            if (!ModuleConfig.Config.AvatarParameterActions.TryGetValue(CurrentAvatarId, out var actions))
+                return [];
+            return actions;
+        }
+    }
+
+    private AvatarParameterAction? _selectedAction;
+    private string _parameterSearch = "";
+
+    private void AddAction()
+    {
+        if (string.IsNullOrEmpty(CurrentAvatarId)) return;
+
+        if (!ModuleConfig.Config.AvatarParameterActions.ContainsKey(CurrentAvatarId))
+            ModuleConfig.Config.AvatarParameterActions[CurrentAvatarId] = new List<AvatarParameterAction>();
+
+        var action = new AvatarParameterAction
+        {
+            ParameterName = "",
+            Action = ControlType.Shock,
+            TriggerKind = ParameterTriggerKind.OnTrue
+        };
+
+        ModuleConfig.Config.AvatarParameterActions[CurrentAvatarId].Add(action);
+        _selectedAction = action;
+        ModuleConfig.SaveDeferred();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void RemoveAction(AvatarParameterAction action)
+    {
+        if (string.IsNullOrEmpty(CurrentAvatarId)) return;
+        if (!ModuleConfig.Config.AvatarParameterActions.TryGetValue(CurrentAvatarId, out var actions)) return;
+
+        actions.Remove(action);
+        if (actions.Count == 0)
+            ModuleConfig.Config.AvatarParameterActions.Remove(CurrentAvatarId);
+
+        if (_selectedAction == action)
+            _selectedAction = null;
+
+        ModuleConfig.SaveDeferred();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnActionChanged()
+    {
+        ModuleConfig.SaveDeferred();
+    }
+
+    private void SelectParameter(string paramName)
+    {
+        if (_selectedAction == null) return;
+        _selectedAction.ParameterName = paramName;
+        ModuleConfig.SaveDeferred();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private IEnumerable<KeyValuePair<string, object?>> FilteredAvatarParams =>
+        ShockOsc.AllAvatarParams
+            .Where(x => !x.Key.StartsWith("ShockOsc/"))
+            .Where(x => string.IsNullOrEmpty(_parameterSearch) ||
+                         x.Key.Contains(_parameterSearch, StringComparison.InvariantCultureIgnoreCase))
+            .OrderBy(x => x.Key);
+
+    private string GetGroupName(Guid groupId)
+    {
+        if (groupId == Guid.Empty) return "_All (All Shockers)";
+        return ModuleConfig.Config.Groups.TryGetValue(groupId, out var group) ? group.Name : "Unknown";
+    }
+
+    private string GetActionSummary(AvatarParameterAction action)
+    {
+        var trigger = action.TriggerKind switch
+        {
+            ParameterTriggerKind.OnTrue => "On True",
+            ParameterTriggerKind.Threshold => $"Threshold >= {action.Threshold:F2}",
+            ParameterTriggerKind.OnChange => "On Change",
+            _ => "Unknown"
+        };
+        return $"{action.Action} | {trigger} | {GetGroupName(action.GroupId)}";
+    }
+
+    private static readonly ControlType[] ActionTypes = [ControlType.Shock, ControlType.Vibrate, ControlType.Sound];
+    private static readonly ParameterTriggerKind[] TriggerKinds = Enum.GetValues<ParameterTriggerKind>();
+
+    private bool _overrideIntensity;
+    private bool _overrideDuration;
+
+    private void OnSelectAction(AvatarParameterAction? action)
+    {
+        _selectedAction = action;
+        if (action != null)
+        {
+            _overrideIntensity = action.OverrideIntensity.HasValue;
+            _overrideDuration = action.OverrideDuration.HasValue;
+        }
+    }
+
+    private void OnOverrideIntensityChanged(bool value)
+    {
+        _overrideIntensity = value;
+        if (_selectedAction == null) return;
+        _selectedAction.OverrideIntensity = value ? (byte)50 : null;
+        ModuleConfig.SaveDeferred();
+    }
+
+    private void OnOverrideDurationChanged(bool value)
+    {
+        _overrideDuration = value;
+        if (_selectedAction == null) return;
+        _selectedAction.OverrideDuration = value ? (ushort)2000 : null;
+        ModuleConfig.SaveDeferred();
+    }
+
+    private byte IntensityValue
+    {
+        get => _selectedAction?.OverrideIntensity ?? 50;
+        set
+        {
+            if (_selectedAction == null) return;
+            _selectedAction.OverrideIntensity = value;
+            ModuleConfig.SaveDeferred();
+        }
+    }
+
+    private ushort DurationValue
+    {
+        get => _selectedAction?.OverrideDuration ?? 2000;
+        set
+        {
+            if (_selectedAction == null) return;
+            _selectedAction.OverrideDuration = value;
+            ModuleConfig.SaveDeferred();
+        }
+    }
+}
+
+@if (string.IsNullOrEmpty(CurrentAvatarId))
+{
+    <MudPaper Outlined="true" Class="rounded-lg" Style="padding: 10px 15px; margin: 20px 0;">
+        <MudText Typo="Typo.h6">No avatar detected. Connect to VRChat to configure avatar parameter actions.</MudText>
+    </MudPaper>
+}
+else
+{
+    <MudPaper Outlined="true" Class="mud-paper-padding">
+        <MudText>Avatar ID: @CurrentAvatarId</MudText>
+    </MudPaper>
+
+    <MudButton OnClick="AddAction" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add"
+               Color="Color.Primary" Style="margin: 10px 0;">
+        Add Parameter Action
+    </MudButton>
+
+    @if (CurrentActions.Count == 0)
+    {
+        <MudPaper Outlined="true" Class="rounded-lg" Style="padding: 10px 15px; margin: 10px 0;">
+            <MudText Typo="Typo.body1">No parameter actions configured for this avatar. Click "Add Parameter Action" to
+                create one.
+            </MudText>
+        </MudPaper>
+    }
+    else
+    {
+        <MudPaper Outlined="true" Class="rounded-lg mud-paper-padding-margin">
+            <MudText>Configured Actions</MudText>
+            <MudDivider/>
+            <br/>
+
+            <MudTable T="AvatarParameterAction" Items="CurrentActions" Hover="true" Dense="true"
+                      SelectedItem="_selectedAction" SelectedItemChanged="OnSelectAction">
+                <HeaderContent>
+                    <MudTh>Parameter</MudTh>
+                    <MudTh>Configuration</MudTh>
+                    <MudTh Style="width: 50px;"></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Parameter">
+                        @(string.IsNullOrEmpty(context.ParameterName) ? "(not set)" : context.ParameterName)
+                    </MudTd>
+                    <MudTd DataLabel="Configuration">@GetActionSummary(context)</MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                                       OnClick="() => RemoveAction(context)"/>
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        </MudPaper>
+    }
+
+    @if (_selectedAction != null)
+    {
+        <MudPaper Outlined="true" Class="rounded-lg mud-paper-padding-margin">
+            <MudText>Action Settings</MudText>
+            <MudDivider/>
+            <br/>
+
+            <MudText Typo="Typo.subtitle2" Style="margin-bottom: 8px;">Select Avatar Parameter</MudText>
+            <MudTextField DebounceInterval="50" Variant="Variant.Outlined" @bind-Value="_parameterSearch"
+                          Label="Search Parameters" Style="margin-bottom: 8px;"/>
+
+            <div style="max-height: 200px; overflow-y: auto; border: 1px solid rgba(255,255,255,0.1); border-radius: 4px; margin-bottom: 16px;">
+                @foreach (var param in FilteredAvatarParams)
+                {
+                    var isSelected = _selectedAction.ParameterName == param.Key;
+                    <MudButton FullWidth="true" Variant="@(isSelected ? Variant.Filled : Variant.Text)"
+                               Color="@(isSelected ? Color.Primary : Color.Default)"
+                               OnClick="() => SelectParameter(param.Key)"
+                               Style="justify-content: flex-start; text-transform: none;">
+                        <MudText Typo="Typo.body2">@param.Key</MudText>
+                        <MudText Typo="Typo.caption" Style="margin-left: auto; opacity: 0.6;">@param.Value</MudText>
+                    </MudButton>
+                }
+            </div>
+
+            <MudTextField Label="Parameter Name (manual entry)" @bind-Value="_selectedAction.ParameterName"
+                          @bind-Value:after="OnActionChanged" Variant="Variant.Filled" Style="margin-bottom: 16px;"/>
+
+            <MudSelect T="ControlType" Label="Action Type" @bind-Value="_selectedAction.Action"
+                       @bind-Value:after="OnActionChanged" Variant="Variant.Filled" Style="margin-bottom: 16px;">
+                @foreach (var actionType in ActionTypes)
+                {
+                    <MudSelectItem Value="@actionType">@actionType</MudSelectItem>
+                }
+            </MudSelect>
+
+            <MudSelect T="ParameterTriggerKind" Label="Trigger" @bind-Value="_selectedAction.TriggerKind"
+                       @bind-Value:after="OnActionChanged" Variant="Variant.Filled" Style="margin-bottom: 16px;">
+                @foreach (var trigger in TriggerKinds)
+                {
+                    <MudSelectItem Value="@trigger">@trigger</MudSelectItem>
+                }
+            </MudSelect>
+
+            @if (_selectedAction.TriggerKind == ParameterTriggerKind.Threshold)
+            {
+                <MudSlider T="float" Size="Size.Large" Min="0f" Max="1f" Step="0.01f"
+                           Class="openshock-slider-length"
+                           @bind-Value="_selectedAction.Threshold"
+                           @bind-Value:after="OnActionChanged">
+                    Threshold: @_selectedAction.Threshold.ToString("F2")
+                </MudSlider>
+            }
+
+            <MudSelect T="Guid" Label="Target Group" @bind-Value="_selectedAction.GroupId"
+                       @bind-Value:after="OnActionChanged" Variant="Variant.Filled" Style="margin-bottom: 16px;">
+                <MudSelectItem T="Guid" Value="@Guid.Empty">_All (All Shockers)</MudSelectItem>
+                @foreach (var group in ModuleConfig.Config.Groups)
+                {
+                    <MudSelectItem T="Guid" Value="@group.Key">@group.Value.Name</MudSelectItem>
+                }
+            </MudSelect>
+
+            <MudCheckBox @bind-Value="_overrideIntensity" Label="Override Intensity"
+                         @bind-Value:after="() => OnOverrideIntensityChanged(_overrideIntensity)"/>
+            @if (_overrideIntensity)
+            {
+                <DebouncedSlider T="byte" Size="Size.Large" Min="0" Max="100" Class="openshock-slider-length"
+                                 @bind-SliderValue="@IntensityValue"
+                                 OnSaveAction="_ => ModuleConfig.SaveDeferred()">
+                    Intensity: @IntensityValue%
+                </DebouncedSlider>
+            }
+
+            <MudCheckBox @bind-Value="_overrideDuration" Label="Override Duration"
+                         @bind-Value:after="() => OnOverrideDurationChanged(_overrideDuration)"/>
+            @if (_overrideDuration)
+            {
+                <DebouncedSlider T="ushort" Size="Size.Large" Min="300" Max="30000" Step="100"
+                                 Class="openshock-slider-length"
+                                 @bind-SliderValue="@DurationValue"
+                                 OnSaveAction="_ => ModuleConfig.SaveDeferred()">
+                    Duration: @MathF.Round(DurationValue / 1000f, 1).ToString(System.Globalization.CultureInfo.InvariantCulture)s
+                </DebouncedSlider>
+            }
+        </MudPaper>
+    }
+}

--- a/ShockOsc/Ui/Pages/Dash/Tabs/AvatarActionsTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/AvatarActionsTab.razor
@@ -145,6 +145,9 @@
 
     private string GetActionSummary(AvatarParameterAction action)
     {
+        if (action.IsLiveControl)
+            return $"{action.Action} | Live Control | {GetGroupName(action.GroupId)}";
+
         var trigger = action.TriggerKind switch
         {
             ParameterTriggerKind.OnTrue => "On True",
@@ -311,22 +314,40 @@ else
                 }
             </MudSelect>
 
-            <MudSelect T="ParameterTriggerKind" Label="Trigger" @bind-Value="_selectedAction.TriggerKind"
-                       @bind-Value:after="OnActionChanged" Variant="Variant.Filled" Style="margin-bottom: 16px;">
-                @foreach (var trigger in TriggerKinds)
-                {
-                    <MudSelectItem Value="@trigger">@trigger</MudSelectItem>
-                }
-            </MudSelect>
+            <MudCheckBox @bind-Value="_selectedAction.IsLiveControl" Label="Live Control (continuous, driven by parameter value)"
+                         @bind-Value:after="OnActionChanged" Style="margin-bottom: 16px;"/>
 
-            @if (_selectedAction.TriggerKind == ParameterTriggerKind.Threshold)
+            @if (_selectedAction.IsLiveControl)
             {
-                <MudSlider T="float" Size="Size.Large" Min="0f" Max="1f" Step="0.01f"
-                           Class="openshock-slider-length"
-                           @bind-Value="_selectedAction.Threshold"
-                           @bind-Value:after="OnActionChanged">
-                    Threshold: @_selectedAction.Threshold.ToString("F2")
-                </MudSlider>
+                <div style="display: flex; gap: 16px; margin-bottom: 16px;">
+                    <MudNumericField T="float" Variant="Variant.Filled" @bind-Value="_selectedAction.LiveControlMin"
+                                     @bind-Value:after="OnActionChanged" Label="Input Min" Style="flex: 1;"
+                                     Step="0.1f"/>
+                    <MudNumericField T="float" Variant="Variant.Filled" @bind-Value="_selectedAction.LiveControlMax"
+                                     @bind-Value:after="OnActionChanged" Label="Input Max" Style="flex: 1;"
+                                     Step="0.1f"/>
+                </div>
+            }
+
+            @if (!_selectedAction.IsLiveControl)
+            {
+                <MudSelect T="ParameterTriggerKind" Label="Trigger" @bind-Value="_selectedAction.TriggerKind"
+                           @bind-Value:after="OnActionChanged" Variant="Variant.Filled" Style="margin-bottom: 16px;">
+                    @foreach (var trigger in TriggerKinds)
+                    {
+                        <MudSelectItem Value="@trigger">@trigger</MudSelectItem>
+                    }
+                </MudSelect>
+
+                @if (_selectedAction.TriggerKind == ParameterTriggerKind.Threshold)
+                {
+                    <MudSlider T="float" Size="Size.Large" Min="0f" Max="1f" Step="0.01f"
+                               Class="openshock-slider-length"
+                               @bind-Value="_selectedAction.Threshold"
+                               @bind-Value:after="OnActionChanged">
+                        Threshold: @_selectedAction.Threshold.ToString("F2")
+                    </MudSlider>
+                }
             }
 
             <MudSelect T="Guid" Label="Target Group" @bind-Value="_selectedAction.GroupId"
@@ -338,19 +359,22 @@ else
                 }
             </MudSelect>
 
-            <MudCheckBox @bind-Value="_overrideIntensity" Label="Override Intensity"
-                         @bind-Value:after="() => OnOverrideIntensityChanged(_overrideIntensity)"/>
-            @if (_overrideIntensity)
+            @if (!_selectedAction.IsLiveControl)
             {
-                <DebouncedSlider T="byte" Size="Size.Large" Min="0" Max="100" Class="openshock-slider-length"
-                                 @bind-SliderValue="@IntensityValue"
-                                 OnSaveAction="_ => ModuleConfig.SaveDeferred()">
-                    Intensity: @IntensityValue%
-                </DebouncedSlider>
-            }
+                <MudCheckBox @bind-Value="_overrideIntensity" Label="Override Intensity"
+                             @bind-Value:after="() => OnOverrideIntensityChanged(_overrideIntensity)"/>
+                @if (_overrideIntensity)
+                {
+                    <DebouncedSlider T="byte" Size="Size.Large" Min="0" Max="100" Class="openshock-slider-length"
+                                     @bind-SliderValue="@IntensityValue"
+                                     OnSaveAction="_ => ModuleConfig.SaveDeferred()">
+                        Intensity: @IntensityValue%
+                    </DebouncedSlider>
+                }
 
-            <MudCheckBox @bind-Value="_overrideDuration" Label="Override Duration"
-                         @bind-Value:after="() => OnOverrideDurationChanged(_overrideDuration)"/>
+                <MudCheckBox @bind-Value="_overrideDuration" Label="Override Duration"
+                             @bind-Value:after="() => OnOverrideDurationChanged(_overrideDuration)"/>
+            }
             @if (_overrideDuration)
             {
                 <DebouncedSlider T="ushort" Size="Size.Large" Min="300" Max="30000" Step="100"

--- a/ShockOsc/Ui/Pages/Dash/Tabs/ChatboxTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/ChatboxTab.razor
@@ -59,7 +59,7 @@
         <MudTextField Variant="Variant.Filled" @bind-Value="ModuleConfig.Config.Chatbox.IgnoredAfk"
                       Label="Ignored Afk Text" @bind-Value:after="OnSettingsValueChange"/>
         <br/>
-        <MudTabs Elevation="2" Outlined="true" ApplyEffectsToContainer="true" PanelClass="pa-6" Class="rounded-lg">
+        <MudTabs Elevation="2" Outlined="true" ApplyEffectsToContainer="true" TabPanelClass="pa-6" Class="rounded-lg">
             @foreach (ControlType controlType in Enum.GetValues(typeof(ControlType)))
             {
                 <MudTabPanel Text="@controlType.ToString()">

--- a/ShockOsc/Ui/Pages/Dash/Tabs/ConfigTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/ConfigTab.razor
@@ -34,12 +34,30 @@
 
     <br/>
 
-    <div style="display: flex; width: 600px; padding-top: 20px;">
-        <MudTextField Class="option-width" Variant="Variant.Filled"
-                      @bind-Value="ModuleConfig.Config.Behaviour.CooldownTime" Label="Cooldown Time (ms)"
-                      @bind-Value:after="OnSettingsValueChangeAsync"/>
-        <MudTextField Class="option-width" Variant="Variant.Filled" @bind-Value="ModuleConfig.Config.Behaviour.HoldTime"
-                      Label="Contact Hold Time (ms)" @bind-Value:after="OnSettingsValueChangeAsync"/>
+    <div style="display: flex; align-items: center; width: 600px; padding-top: 20px; gap: 12px;">
+        <DebouncedSlider T="uint" Size="Size.Large" Class="openshock-slider-length"
+                         @bind-SliderValue="@ModuleConfig.Config.Behaviour.CooldownTime"
+                         OnSaveAction="_ => OnSettingsValueChange()"
+                         Min="0" Max="30000" Step="500">
+            Cooldown: @MathF.Round(ModuleConfig.Config.Behaviour.CooldownTime / 1000f, 1).ToString(CultureInfo.InvariantCulture)s
+        </DebouncedSlider>
+        <MudNumericField T="uint" Variant="Variant.Outlined" Style="max-width: 90px;"
+                         @bind-Value="ModuleConfig.Config.Behaviour.CooldownTime"
+                         @bind-Value:after="OnSettingsValueChangeAsync"
+                         Min="0" Label="ms"/>
+    </div>
+
+    <div style="display: flex; align-items: center; width: 600px; padding-top: 20px; gap: 12px;">
+        <DebouncedSlider T="uint" Size="Size.Large" Class="openshock-slider-length"
+                         @bind-SliderValue="@ModuleConfig.Config.Behaviour.HoldTime"
+                         OnSaveAction="_ => OnSettingsValueChange()"
+                         Min="0" Max="1000" Step="10">
+            Hold Time: @ModuleConfig.Config.Behaviour.HoldTime ms
+        </DebouncedSlider>
+        <MudNumericField T="uint" Variant="Variant.Outlined" Style="max-width: 90px;"
+                         @bind-Value="ModuleConfig.Config.Behaviour.HoldTime"
+                         @bind-Value:after="OnSettingsValueChangeAsync"
+                         Min="0" Label="ms"/>
     </div>
 
     <div style="display: flex; width: 600px; padding-top: 20px;">
@@ -179,6 +197,26 @@
                           @bind-Value:after="OnSettingsValueChange"/>
         }
     }
+</MudPaper>
+
+<MudPaper Outlined="true" Class="rounded-lg mud-paper-padding-margin">
+    <MudExpansionPanels Elevation="0">
+        <MudExpansionPanel Text="Advanced">
+            <div style="display: flex; align-items: center; width: 600px; gap: 12px;">
+                <DebouncedSlider T="uint" Size="Size.Large" Class="openshock-slider-length"
+                                 @bind-SliderValue="@ModuleConfig.Config.Behaviour.CheckLoopIntervalMs"
+                                 OnSaveAction="_ => OnSettingsValueChange()"
+                                 Min="10" Max="200" Step="5">
+                    Check Loop Interval: @ModuleConfig.Config.Behaviour.CheckLoopIntervalMs ms
+                </DebouncedSlider>
+                <MudNumericField T="uint" Variant="Variant.Outlined" Style="max-width: 90px;"
+                                 @bind-Value="ModuleConfig.Config.Behaviour.CheckLoopIntervalMs"
+                                 @bind-Value:after="OnSettingsValueChangeAsync"
+                                 Min="10" Label="ms"
+                                 HelperText="Next connection"/>
+            </div>
+        </MudExpansionPanel>
+    </MudExpansionPanels>
 </MudPaper>
 
 @code {

--- a/ShockOsc/Ui/Pages/Dash/Tabs/DebugTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/DebugTab.razor
@@ -1,4 +1,4 @@
-﻿@using OpenShock.Desktop.ModuleBase
+i﻿@using OpenShock.Desktop.ModuleBase
 @using OpenShock.Desktop.ModuleBase.Api
 @using OpenShock.ShockOSC.Services
 @using OpenShock.ShockOSC.Utils
@@ -96,15 +96,12 @@
 
     private async Task UpdateParams()
     {
-        while (!_cts.IsCancellationRequested)
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(100));
+        while (await timer.WaitForNextTickAsync(_cts.Token))
         {
-            if (!_updateQueued)
-                continue;
+            if (!_updateQueued) continue;
             _updateQueued = false;
-
             await InvokeAsync(StateHasChanged);
-
-            await Task.Delay(100);
         }
     }
 

--- a/ShockOsc/Ui/Pages/Dash/Tabs/DebugTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/DebugTab.razor
@@ -7,7 +7,22 @@
 @page "/dash/debug"
 
 <MudPaper Outlined="true" Class="mud-paper-padding">
-    <MudText>Avatar ID: @ShockOsc.AvatarId</MudText>
+    <div style="display: flex; align-items: center; gap: 16px;">
+        <MudChip T="string"
+                 Color="@(ShockOsc.IsGameConnected ? Color.Success : Color.Error)"
+                 Variant="Variant.Filled"
+                 Size="Size.Small">
+            @if (ShockOsc.IsGameConnected)
+            {
+                @($"Connected{(ShockOsc.IsConnectedViaOscQuery ? " (OSCQuery)" : " (Manual)")}")
+            }
+            else
+            {
+                @("Not Connected")
+            }
+        </MudChip>
+        <MudText>Avatar ID: @ShockOsc.AvatarId</MudText>
+    </div>
 </MudPaper>
 <MudPaper Outlined="true" Class="mud-paper-padding-margin">
     <MudText>OSC Parameters</MudText>
@@ -72,9 +87,12 @@
     protected override void OnInitialized()
     {
         _onParamsVhangeSubscription = ShockOsc.OnParamsChangeObservable.Subscribe(OnParamsChange);
+        ShockOsc.OnGameConnectionChanged += OnConnectionChanged;
 
         OsTask.Run(UpdateParams);
     }
+
+    private void OnConnectionChanged() => _updateQueued = true;
 
     private async Task UpdateParams()
     {
@@ -96,6 +114,7 @@
 
     public async ValueTask DisposeAsync()
     {
+        ShockOsc.OnGameConnectionChanged -= OnConnectionChanged;
         _onParamsVhangeSubscription?.Dispose();
         await _cts.CancelAsync();
     }

--- a/ShockOsc/Ui/Pages/Dash/Tabs/DebugTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/DebugTab.razor
@@ -1,4 +1,4 @@
-i﻿@using OpenShock.Desktop.ModuleBase
+@using OpenShock.Desktop.ModuleBase
 @using OpenShock.Desktop.ModuleBase.Api
 @using OpenShock.ShockOSC.Services
 @using OpenShock.ShockOSC.Utils

--- a/ShockOsc/Ui/Pages/Dash/Tabs/GroupsTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/GroupsTab.razor
@@ -324,8 +324,18 @@
         <MudCollapse Expanded="CurrentGroup.OverrideCooldownTime">
             <br/>
 
-            <MudTextField Class="option-width" Variant="Variant.Filled" @bind-Value="CurrentGroup.CooldownTime"
-                          Label="Cooldown Time (ms)" @bind-Value:after="OnGroupSettingsValueChange"/>
+            <div style="display: flex; align-items: center; gap: 12px;">
+                <DebouncedSlider T="uint" Size="Size.Large" Class="openshock-slider-length"
+                                 @bind-SliderValue="@CurrentGroup.CooldownTime"
+                                 OnSaveAction="_ => ModuleConfig.SaveDeferred()"
+                                 Min="0" Max="30000" Step="500">
+                    Cooldown: @MathF.Round(CurrentGroup.CooldownTime / 1000f, 1).ToString(CultureInfo.InvariantCulture)s
+                </DebouncedSlider>
+                <MudNumericField T="uint" Variant="Variant.Outlined" Style="max-width: 90px;"
+                                 @bind-Value="CurrentGroup.CooldownTime"
+                                 @bind-Value:after="OnGroupSettingsValueChange"
+                                 Min="0" Label="ms"/>
+            </div>
 
         </MudCollapse>
     </MudPaper>

--- a/ShockOsc/Ui/Pages/Dash/Tabs/GroupsTab.razor
+++ b/ShockOsc/Ui/Pages/Dash/Tabs/GroupsTab.razor
@@ -10,6 +10,7 @@
 @using ProgramGroup = OpenShock.ShockOSC.Models.ProgramGroup
 
 @page "/dash/groups"
+@implements IDisposable
 
 @code {
 
@@ -161,7 +162,7 @@
         InvokeAsync(StateHasChanged);
     }
 
-    private void Dispose()
+    public void Dispose()
     {
         UnderscoreConfig.OnGroupConfigUpdate -= OnGroupConfigUpdate;
     }
@@ -324,7 +325,7 @@
             <br/>
 
             <MudTextField Class="option-width" Variant="Variant.Filled" @bind-Value="CurrentGroup.CooldownTime"
-                          Label="Cooldown Time" @bind-Value:after="OnGroupSettingsValueChange"/>
+                          Label="Cooldown Time (ms)" @bind-Value:after="OnGroupSettingsValueChange"/>
 
         </MudCollapse>
     </MudPaper>

--- a/copy-module-dll.cmd
+++ b/copy-module-dll.cmd
@@ -1,1 +1,0 @@
-copy ShockOsc\bin\Debug\net9.0\OpenShock.ShockOSC.dll %appdata%\OpenShock\Desktop\modules\openshock.shockosc\OpenShock.ShockOSC.dll


### PR DESCRIPTION
# Summary

  - Fix per-group cooldown override: OscHandler.SendParams() was hardcoded to use the global cooldown time, ignoring group-level OverrideCooldownTime/CooldownTime overrides — the _Cooldown, _CooldownPercentage, and _Intensity feedback parameters sent to VRChat were wrong for any group with a custom cooldown
  - Avatar Parameter Actions: New system for mapping arbitrary avatar parameters to shocker actions, configurable per-avatar from a new UI tab. Supports one-shot triggers (OnTrue, OnFalse, Threshold, OnChange) and live continuous control driven by parameter value with configurable input range
  - Game connection indicator: Debug tab shows a color-coded chip with connection status and whether it's via OSCQuery or manual config
  - Replace Task.Delay loops with CancellationToken + PeriodicTimer: Background loops (ReceiverLoop, SenderLoop, CheckLoop) now shut down deterministically via cancellation instead of a 1-second sleep hack
  - UI improvements: Timing settings (cooldown, hold time) converted from raw text fields to sliders with numeric input for custom values; check loop interval exposed as an advanced setting; group cooldown override label now shows "(ms)" unit

## Test plan

  - [ ] Set a per-group cooldown override, verify the _Cooldown and _CooldownPercentage avatar parameters in VRChat match the group's cooldown, not the global one
  - [ ] Configure an avatar parameter action with each trigger kind (OnTrue, OnFalse, Threshold, OnChange) and verify they fire correctly
  - [ ] Configure a live control action, verify continuous intensity tracks the parameter value and stops when it reaches 0
  - [ ] Test live control with non-standard ranges (e.g. -1 to 1 radial, 0-7 int) and verify correct intensity mapping
  - [ ] Verify the connection chip in the Debug tab updates on connect/disconnect
  - [ ] Change the check loop interval in Advanced settings, reconnect, and verify responsiveness changes
  - [ ] Verify the cooldown/hold time sliders work and that typing a value beyond the slider range is accepted